### PR TITLE
Allow static linking with MSVC

### DIFF
--- a/C/Makefile
+++ b/C/Makefile
@@ -7,6 +7,7 @@ SFLAGS = -O2
 CFLAGS = $(EXTRA_CFLAGS) -Wall -Wextra -std=c99
 SHARED_SFLAGS = $(SFLAGS) -flto
 SHARED_CFLAGS = $(CFLAGS) -fPIC
+STATIC_CFLAGS = $(CFLAGS) -DLIBATRAC9_STATIC_DEFINE
 LDFLAGS = -shared -s -Wl,--version-script=libatrac9.version
 
 SRCDIR = src
@@ -51,7 +52,7 @@ $(STATIC_NAME): $(STATIC_OBJS)
 	$(AR) rcs $@ $^
 
 $(STATIC_OBJS): $(STATIC_OBJDIR)/%.o : $(SRCDIR)/%.c
-	$(CC) $(SFLAGS) $(CFLAGS) -c $< -o $@
+	$(CC) $(SFLAGS) $(STATIC_CFLAGS) -c $< -o $@
 
 clean:
 	$(RM) $(SHARED_OBJS) $(SHARED_NAME) $(STATIC_OBJS) $(STATIC_NAME)

--- a/C/src/libatrac9.h
+++ b/C/src/libatrac9.h
@@ -4,13 +4,19 @@ extern "C" {
 #endif
 
 #ifdef _MSC_VER
-#ifdef COMPILING_DLL 
-#define DLLEXPORT __declspec(dllexport)
+#define LIBATRAC9_DLLEXPORT __declspec(dllexport)
+#define LIBATRAC9_DLLIMPORT __declspec(dllimport)
 #else
-#define DLLEXPORT __declspec(dllimport)  
+#define LIBATRAC9_DLLEXPORT
+#define LIBATRAC9_DLLIMPORT
 #endif
+
+#if defined(LIBATRAC9_STATIC_DEFINE)
+#define LIBATRAC9_EXPORT
+#elif defined(COMPILING_DLL)
+#define LIBATRAC9_EXPORT LIBATRAC9_DLLEXPORT
 #else
-#define DLLEXPORT
+#define LIBATRAC9_EXPORT LIBATRAC9_DLLIMPORT
 #endif
 
 #define ATRAC9_CONFIG_DATA_SIZE 4
@@ -26,13 +32,13 @@ typedef struct {
 	unsigned char configData[ATRAC9_CONFIG_DATA_SIZE];
 } Atrac9CodecInfo;
 
-DLLEXPORT void* Atrac9GetHandle(void);
-DLLEXPORT void Atrac9ReleaseHandle(void* handle);
+LIBATRAC9_EXPORT void* Atrac9GetHandle(void);
+LIBATRAC9_EXPORT void Atrac9ReleaseHandle(void* handle);
 
-DLLEXPORT int Atrac9InitDecoder(void* handle, unsigned char *pConfigData);
-DLLEXPORT int Atrac9Decode(void* handle, const unsigned char *pAtrac9Buffer, short *pPcmBuffer, int *pNBytesUsed);
+LIBATRAC9_EXPORT int Atrac9InitDecoder(void* handle, unsigned char *pConfigData);
+LIBATRAC9_EXPORT int Atrac9Decode(void* handle, const unsigned char *pAtrac9Buffer, short *pPcmBuffer, int *pNBytesUsed);
 
-DLLEXPORT int Atrac9GetCodecInfo(void* handle, Atrac9CodecInfo *pCodecInfo);
+LIBATRAC9_EXPORT int Atrac9GetCodecInfo(void* handle, Atrac9CodecInfo *pCodecInfo);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
With these changes, a project can now statically link with libatrac9 using MSVC (requires to define `LIBATRAC9_STATIC_DEFINE`). No changes for the shared lib